### PR TITLE
fix: update ping timeout error handling to return an error instance instead of nil

### DIFF
--- a/engine/socket-without-upgrade.go
+++ b/engine/socket-without-upgrade.go
@@ -473,7 +473,7 @@ func (s *socketWithoutUpgrade) _resetPingTimeout() {
 	delay := s._pingInterval + s._pingTimeout
 	s._pingTimeoutTime.Store(float64(time.Now().UnixMilli() + delay))
 	s._pingTimeoutTimer.Store(utils.SetTimeout(func() {
-		s._onClose("ping timeout", nil)
+		s._onClose("ping timeout", errors.New("ping timeout"))
 	}, time.Duration(delay)*time.Millisecond))
 	if s.opts.AutoUnref() {
 		s._pingTimeoutTimer.Load().Unref()
@@ -553,7 +553,7 @@ func (s *socketWithoutUpgrade) HasPingExpired() bool {
 		client_socket_log.Debug("throttled timer detected, scheduling connection close")
 		s._pingTimeoutTime.Store(0)
 
-		go s._onClose("ping timeout", nil)
+		go s._onClose("ping timeout", errors.New("ping timeout"))
 	}
 
 	return hasExpired


### PR DESCRIPTION
Fix https://github.com/zishang520/socket.io-client-go/blob/a8baa9db01700d4fa9a01819a87fd26417e2b08a/socket/manager.go#L357